### PR TITLE
change type for typedoc dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,11 +22,13 @@
   "license": "ISC",
   "dependencies": {
     "event-stream": "^3.3.1",
-    "gulp-util": "^3.0.6",
-    "typedoc": "^0.3.12"
+    "gulp-util": "^3.0.6"
   },
   "devDependencies": {
     "del": "^1.2.0",
     "gulp": "^3.9.0"
+  },
+  "peerDependencies": {
+    "typedoc": ">= 0.3.9 || 1.8.10"
   }
 }


### PR DESCRIPTION
`depend` -> `peer depend`

Related: #13 

## Notes

 * npm installs peer depends automatically. npm@3(next major version) is not.
 * This breaks some repositories of this plugin's users because this needs typedoc on dependecies or devDependencies. So, we may update major version on next release.


