### PR TITLE
Keep typedoc "logger" option, if set

### DIFF
--- a/index.js
+++ b/index.js
@@ -57,7 +57,7 @@ function typedoc(options) {
 				if (project) {
 					if (out) app.generateDocs(project, out);
 					if (json) app.generateJson(project, json);
-					if (app.logger.hasOwnProperty("hasErrors") && app.logger.hasErrors()) {
+					if (app.logger.hasErrors()) {
 						stream.emit("error", new PluginError(PLUGIN_NAME, "There were errors generating TypeDoc output, see above."));
 						stream.emit("end");
 						return;

--- a/index.js
+++ b/index.js
@@ -36,17 +36,19 @@ function typedoc(options) {
 			var version = options.version;
 			delete options.version;
 
-			// reduce console logging
-			options.logger = function(message, level, newline) {
-				if (level === 3) {
-					gutil.log(gutil.colors.red(message));
+			if (!options.logger) {
+				// reduce console logging
+				options.logger = function(message, level, newline) {
+					if (level === 3) {
+						gutil.log(gutil.colors.red(message));
+					}
 				}
 			}
 
 			// typedoc instance
 			var app = new typedocModule.Application(options);
 
-			if (version) {
+			if (version && options.logger !== "none") {
 				gutil.log(app.toString());
 			}
 			try {
@@ -55,7 +57,7 @@ function typedoc(options) {
 				if (project) {
 					if (out) app.generateDocs(project, out);
 					if (json) app.generateJson(project, json);
-					if (app.logger.hasErrors()) {
+					if (app.logger.hasOwnProperty("hasErrors") && app.logger.hasErrors()) {
 						stream.emit("error", new PluginError(PLUGIN_NAME, "There were errors generating TypeDoc output, see above."));
 						stream.emit("end");
 						return;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gulp-typedoc",
-  "version": "2.0.3",
+  "version": "2.0.3-fixlogger",
   "description": "Gulp plugin for the TypeDoc typescript documentation tool.",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gulp-typedoc",
-  "version": "2.0.3-fixlogger",
+  "version": "2.0.3",
   "description": "Gulp plugin for the TypeDoc typescript documentation tool.",
   "repository": {
     "type": "git",


### PR DESCRIPTION
As commented in #21, typedoc's "logger" property would always be overwritten by gulp-typedoc; this PR fixes it.

Also, if 'logger' is set to "none", this will prevent gulp-typedoc from writing library versions to the stdout, even if the 'version' is set to true (no other behavior is affected - the version is still printed at the HTML / JSON).

Before the PR (calling gulp-typedoc with options.logger = "none"):

![Before logger pull request](https://user-images.githubusercontent.com/12532376/30231282-97426320-94c0-11e7-9cc6-240bd73f3dc4.png)

After (same gulp task):

![After logger pull request](https://user-images.githubusercontent.com/12532376/30231206-35e818a4-94c0-11e7-9b7a-9286cbdd33b1.png)
