### PR TITLE
Add type definitions

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,140 @@
+declare namespace gulpTypedoc {
+  type Logger = (message: string, level: number, newline: boolean) => void;
+
+  /**
+   * Typedoc options
+   */
+  interface Options {
+    /**
+     * Specifies the location the documentation should be written to.
+     */
+    out: string;
+
+    /**
+     * Specifies the output mode the project is used to be compiled with.
+     */
+    mode?: "file" | "modules";
+
+    /**
+     * Specifies the location and file name a json file describing the project is written to. When specified no
+     * documentation will be generated.
+     */
+    json?: string;
+
+    /**
+     * Exclude files by the given pattern when a path is provided as source. Supports standard minimatch patterns
+     * (see TypeStrong/typedoc#170)
+     */
+    exclude?: string;
+
+    /**
+     * Turn on parsing of .d.ts declaration files.
+     */
+    includeDeclarations?: boolean;
+
+    /**
+     * Define a pattern for files that should be considered being external.
+     */
+    externalPattern?: string;
+
+    /**
+     * Prevent externally resolved TypeScript files from being documented.
+     */
+    excludeExternals?: boolean;
+
+    /**
+     * Prevent private members from being included in the generated documentation.
+     */
+    excludePrivate?: boolean;
+
+    /**
+     * Prevent protected members from being included in the generated documentation.
+     */
+    excludeProtected?: boolean;
+
+    /**
+     * Specify module code generation: "commonjs", "amd", "system" or "umd".
+     */
+    module?: "commonjs" | "amd" | "system" | "umd"
+
+    /**
+     * Specify ECMAScript target version: "ES3" (default), "ES5" or "ES6"
+     */
+    target?: string;
+
+    /**
+     * Specify the path to the theme that should be used.
+     */
+    theme?: string;
+
+    /**
+     * Set the name of the project that will be used in the header of the template.
+     */
+    name?: string;
+
+    /**
+     * Path to the readme file that should be displayed on the index page. Pass `none` to disable the index page and
+     * start the documentation on the globals page.
+     */
+    readme?: string;
+
+    /**
+     * Specify the npm plugins that should be loaded.
+     */
+    plugins?: string[];
+
+    /**
+     * Do not print the TypeDoc link at the end of the page.
+     */
+    hideGenerator?: boolean;
+
+    /**
+     * Set the Google Analytics tracking ID and activate tracking code.
+     */
+    gaID?: string;
+
+    /**
+     * Set the site name for Google Analytics. Defaults to `auto`
+     */
+    gaSite?: string;
+
+    /**
+     * Specifies the fully qualified name of the root symbol. Defaults to global namespace.
+     */
+    entryPoint?: string;
+
+    /**
+     * Use specified revision or branch instead of the last revision for linking to GitHub source files.
+     */
+    gitRevision?: string;
+
+    /**
+     * Specifies the location to look for included documents. One may use [[include:FILENAME]] in comments to include
+     * documents from this location.
+     */
+    includes?: string;
+
+    /**
+     * Specifies the location with media files that should be copied to the output directory. In order to create a link
+     * to media files use the pattern media://FILENAME in comments.
+     */
+    media?: string;
+
+    verbose?: boolean;
+
+    version?: boolean;
+
+    logger?: Logger | "none";
+  }
+}
+
+/**
+ * The plugin takes an object, of which all properties are passed transparently to typedoc. Pipe in TypeScript files.
+ * The documentation files are not piped out.
+ *
+ * @param options Typedoc options
+ * @return Empty output stream (ends when the files are written)
+ */
+declare function gulpTypedoc(options: gulpTypedoc.Options): NodeJS.ReadWriteStream;
+
+export = gulpTypedoc;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "gulp-typedoc",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -10,7 +10,7 @@
       "integrity": "sha512-Id1hnmfd+7G9K+jWz2syfMcpymx2mj6B1y4C72vAoYQzxOA79UhY/kNvOCyb9yYR1SoSaHyhwcYtWKKqUiLTZA==",
       "dev": true,
       "requires": {
-        "@types/node": "8.0.28"
+        "@types/node": "9.3.0"
       }
     },
     "@types/glob": {
@@ -20,7 +20,7 @@
       "dev": true,
       "requires": {
         "@types/minimatch": "2.0.29",
-        "@types/node": "8.0.28"
+        "@types/node": "9.3.0"
       }
     },
     "@types/handlebars": {
@@ -54,9 +54,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "8.0.28",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-8.0.28.tgz",
-      "integrity": "sha512-HupkFXEv3O3KSzcr3Ylfajg0kaerBg1DyaZzRBBQfrU3NN1mTBRE7sCveqHwXLS5Yrjvww8qFzkzYQQakG9FuQ==",
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-9.3.0.tgz",
+      "integrity": "sha512-wNBfvNjzsJl4tswIZKXCFQY0lss9nKUyJnG6T94X/eqjRgI2jHZ4evdjhQYBSan/vGtF6XVXPApOmNH2rf0KKw==",
       "dev": true
     },
     "@types/shelljs": {
@@ -66,7 +66,7 @@
       "dev": true,
       "requires": {
         "@types/glob": "5.0.32",
-        "@types/node": "8.0.28"
+        "@types/node": "9.3.0"
       }
     },
     "align-text": {
@@ -2148,6 +2148,12 @@
           "requires": {
             "brace-expansion": "1.1.8"
           }
+        },
+        "typescript": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.4.1.tgz",
+          "integrity": "sha1-w8yxbdqgsjFN4DHn5v7onlujRrw=",
+          "dev": true
         }
       }
     },
@@ -2158,9 +2164,9 @@
       "dev": true
     },
     "typescript": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.4.1.tgz",
-      "integrity": "sha1-w8yxbdqgsjFN4DHn5v7onlujRrw=",
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.6.2.tgz",
+      "integrity": "sha1-PFtv1/beCRQmkCfwPAlGdY92c6Q=",
       "dev": true
     },
     "uglify-js": {

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "type": "git",
     "url": "https://github.com/rogierschouten/gulp-typedoc.git"
   },
+  "types": "index.d.ts",
   "main": "index.js",
   "scripts": {
     "test": "mocha test/test.js && tsc -p test-types"

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "main": "index.js",
   "scripts": {
-    "test": "mocha test/test.js"
+    "test": "mocha test/test.js && tsc -p test-types"
   },
   "keywords": [
     "typedoc",
@@ -28,12 +28,14 @@
     "plugin-error": "^0.1.2"
   },
   "devDependencies": {
+    "@types/node": "^9.3.0",
     "chai": "^4.1.2",
     "fs-extra": "^4.0.1",
     "gulp": "^3.9.1",
     "mocha": "^3.5.0",
     "rimraf": "^2.6.1",
-    "typedoc": "^0.8.0"
+    "typedoc": "^0.8.0",
+    "typescript": "^2.6.2"
   },
   "peerDependencies": {
     "typedoc": ">=0.3.9"

--- a/test-types/test.ts
+++ b/test-types/test.ts
@@ -1,0 +1,30 @@
+import gulpTypedoc from "gulp-typedoc";
+
+const options: gulpTypedoc.Options = {
+  out: "./out",
+  mode: "file",
+  json: "./out/test.json",
+  exclude: "**/*.exclude.ts",
+  externalPattern: "**/*.external.ts",
+  excludeExternals: false,
+  excludePrivate: false,
+  excludeProtected: false,
+  module: "commonjs",
+  target: "es5",
+  theme: "default",
+  name: "Test types",
+  readme: "./README.md",
+  plugins: ["foo", "bar"],
+  hideGenerator: false,
+  gaID: "123",
+  gaSite: "auto",
+  gitRevision: "6352ee5caf389192d8dc1baab2ccce9362857954",
+  includes: "./includes",
+  media: "./media",
+  includeDeclarations: true,
+  verbose: true,
+  version: true,
+  logger: "none",
+};
+
+const result: NodeJS.ReadWriteStream = gulpTypedoc(options);

--- a/test-types/tsconfig.json
+++ b/test-types/tsconfig.json
@@ -1,0 +1,24 @@
+{
+  "compilerOptions": {
+    "allowSyntheticDefaultImports": true,
+    "alwaysStrict": true,
+    "baseUrl": ".",
+    "locale": "en-us",
+    "module": "commonjs",
+    "moduleResolution": "node",
+    "newLine": "lf",
+    "noEmit": true,
+    "paths": {
+      "gulp-typedoc": [
+        "../index.d.ts"
+      ]
+    },
+    "rootDir": ".",
+    "strict": true,
+    "target": "es2017"
+  },
+  "files": [
+    "./test.ts"
+  ],
+  "exclude": []
+}


### PR DESCRIPTION
This commit add type definitions for `gulp-typedoc`. These type
definitions are more complete than the ones from DT. They export all
the types (`Options` and `Logger`), are documented and tested.

The tests try to compile a file in `noEmit` mode to verify that it
type-checks. This adds the new devDevdependencies `@types/node` and
`typescript`.

This is a semver minor change (feature).

- See rogierschouten/gulp-typedoc#20